### PR TITLE
Add test verifying metaprob.examples.all can be required

### DIFF
--- a/test/metaprob/examples/all_test.clj
+++ b/test/metaprob/examples/all_test.clj
@@ -1,5 +1,6 @@
 (ns metaprob.examples.all-test
-  (:require [clojure.test :refer :all]
-            [metaprob.examples.all :as all]))
+  (:require [clojure.test :refer :all]))
 
-(defn foo [] 'hello)
+(deftest test-require
+  (testing "can the namespace be required"
+    (is (any? (require 'metaprob.examples.all)))))


### PR DESCRIPTION
## What does this do?

Replaces the dummy function `foo` in `metaprob.examples.all-test` with a test that explicitly verifies that `metaprob.examples.all` can be required. 

Fixes #67.

## Why should we do this?

See the discussion in #67.

## How do I test this?

First run the new test and watch it pass:

```
clojure -Atest -n metaprob.examples.all-test
```

Then add a line to `metaprob.examples.all` that, when evaluated, will trigger an exception. For example:

```
(define foo (/ 1 0))
```

Now run the new test again and watch it fail.