### PR TITLE
Move state implementations into separate namespaces

### DIFF
--- a/src/metaprob/state/common.clj
+++ b/src/metaprob/state/common.clj
@@ -1,0 +1,75 @@
+(ns metaprob.state.common)
+
+(def rest-marker "rest")
+
+(defn state? [val]
+  (or (seq? val)                        ;Strings are not seqs
+      (vector? val)
+      (map? val)))
+
+(defn empty-state? [state]
+  (and (state? state)
+       (empty? state)))
+
+(defn value-only-trace?
+  "Convert heterogeneous canonical clojure form to hash-map"
+  [tr]
+  (and (map? tr)
+       (= (count tr) 1)
+       (contains? tr :value)))
+
+(defn state-to-map
+  "Convert heterogeneous canonical clojure form to hash-map"
+  [state]
+  (cond (map? state) state
+
+        (seq? state)
+        (if (empty? state)
+          {}
+          {:value (first state) rest-marker (rest state)})
+
+        (vector? state)
+        (into {} (map (fn [i x] [i {:value x}])
+                      (range (count state))
+                      state))
+
+        true (assert false ["not a state" state])))
+
+(defn keys-sans-value [m]
+  (let [ks (remove #{:value} (keys m))]
+    (if (= ks nil)
+      '()
+      ks)))
+
+;; Constructors
+
+(defn empty-state [] {})    ; 'lein test' passes with () and [] here as well
+
+(defn map-to-state
+  "Convert hash-map to heterogeneous canonical clojure form."
+  [m]
+  ;; I'm sorry I failed to record the reason that the 'don't be lazy'
+  ;; command is there; there must have been a failure at some point that
+  ;; I attributed to laziness in these maps.
+  (doseq [entry m] true)    ;Don't be lazy!
+  (let [n (count m)]
+    (if (= n 0)
+      (empty-state)
+      (let [value (get m :value :no-value)]
+        (if (= value :no-value)
+          ;; Has no value: could be a vector.
+          (if (every? (fn [i] (value-only-trace? (get m i)))
+                      (range n))
+            (vec (for [i (range n)] (get (get m i) :value)))
+            m)
+          ;; Has value: could be a seq / list.
+          (if (= n 2)
+            (let [rest (get m rest-marker :no-value)]
+              (if (= rest :no-value)
+                m                 ;No "rest", so just an ordinary dict
+                (if (empty-state? rest)
+                  (cons value '())    ;Allow termination in () [] or {}
+                  (if (seq? rest)
+                    (cons value rest)
+                    m))))
+            m))))))

--- a/src/metaprob/state/steady.clj
+++ b/src/metaprob/state/steady.clj
@@ -1,0 +1,26 @@
+(ns metaprob.state.steady
+  "Simple but slower implementation of state primitives."
+  (:require [metaprob.state.common :as common]))
+
+(defn has-value? [state]
+  (not (= (get (common/state-to-map state) :value :no-value) :no-value)))
+
+(defn value [state]
+  (get (common/state-to-map state) :value))
+
+(defn has-subtrace? [state key]
+  (contains? (common/state-to-map state) key))
+
+(defn subtrace [state key]
+  (let [val (get (common/state-to-map state) key)]
+    (assert (not (= val nil))
+            ["no such subtrace" key state])
+    val))
+
+(defn state-keys
+  "Returns a seq of keys (without the :value marker)"
+  [state]
+  (common/keys-sans-value (common/state-to-map state)))
+
+(defn subtrace-count [state]
+  (count (state-keys state)))

--- a/src/metaprob/state/unsteady.clj
+++ b/src/metaprob/state/unsteady.clj
@@ -1,0 +1,53 @@
+(ns metaprob.state.unsteady
+  "Obscure but faster implementation of state primitives."
+  (:require [metaprob.state.common :as common]))
+
+(defn has-value? [state]
+  (cond (seq? state) (not (empty? state))
+        (vector? state) false
+        (map? state) (not (= (get state :value :no-value) :no-value))
+        true (assert false ["not a state" state])))
+
+(defn value [state]
+  (cond (seq? state) (first state)
+        (vector? state) (assert false "no value")
+        (map? state)
+        (let [value (get state :value :no-value)]
+          (assert (not (= value :no-value)) ["state has no value" state])
+          value)
+        true (assert false ["not a state" state])))
+
+(defn has-subtrace? [state key]
+  (cond (seq? state) (and (not (empty? state))
+                          (= key common/rest-marker))
+        (vector? state) (and (integer? key)
+                             (>= key 0)
+                             (< key (count state)))
+        (map? state) (contains? state key)
+        true (assert false ["not a state" state])))
+
+(defn subtrace [state key]
+  (let [val (cond (seq? state) (rest state)
+                  (vector? state) {:value (nth state key)}
+                  (map? state) (get state key)
+                  true (assert false ["not a state" state]))]
+    (assert (not (= val nil))
+            ["no such subtrace" key state])
+    val))
+
+(defn state-keys
+  "Returns a seq of keys (without the :value marker)"
+  [state]
+  (cond (seq? state) (if (empty? state) '() (list common/rest-marker))
+        (vector? state) (range (count state))
+        (map? state) (common/keys-sans-value state)
+        true (assert false ["not a state" state])))
+
+(defn subtrace-count [state]
+  (cond (seq? state) (if (empty? state) 0 1)
+        (vector? state) (count state)
+        (map? state) (let [n (count state)]
+                       (if (= (get state :value :no-value) :no-value)
+                         n
+                         (- n 1)))
+        true (assert false ["not a state" state])))


### PR DESCRIPTION
## What does this do?
1. Separates the "steady", "unsteady", and "common" state implementations into separate namespaces. 
1. Moves some comments into docstrings.

## Why should we do this?
1. Clearly separates the "steady" state implementation from the "unsteady" one.
1. Might provide a small performance boost.
1. ~Lays the groundwork for testing both state implementations.~ Not required per [@jar398's comment](https://github.com/probcomp/metaprob-clojure/pull/76#issuecomment-427689189).
1. Lays the groundwork for introducing a state protocol.

## How do I test this?
```
make test
```