### PR TITLE
Fix log-categorical

### DIFF
--- a/src/metaprob/distributions.clj
+++ b/src/metaprob/distributions.clj
@@ -109,21 +109,16 @@
                       (scan (+ i 1) (rest probs) p))))
      (scan 0 (scores-to-probabilities scores) 0.0))
    (gen [i [scores]]
-     ;; iterate over scores, accumulate running sum, for first i scores.
-     (define scan (gen [j scores running-score]
-                    (define score (+ (first scores) running-score))
-                    (if (> j i)
-                      running-score
-                      (scan (+ j 1) (rest scores) score))))
-     (scan 0 scores 0.0))))
+     (nth (scores-to-probabilities scores) i))))
 
 ;;  ^:private
 (define scores-to-probabilities
   (gen [scores]
-    (define weights (map exp (to-immutable-list scores)))
-    ;; reduce probably won't work
-    (define normalizer (apply add (to-immutable-list weights)))
-    (map (gen [w] (/ w normalizer)) weights)))
+    (define max-score (apply clojure.core/max scores))
+    (define numerically-stable-scores (map (gen [x] (- x max-score)) (to-immutable-list scores)))
+    (define weights (map exp numerically-stable-scores))
+    (define log-normalizer (+ (log (apply + weights)) max-score))
+    (map (gen [w] (exp (- w log-normalizer))) (to-immutable-list scores))))
 
 
 ;; ----------------------------------------------------------------------------


### PR DESCRIPTION
This uses the [log-sum-exp trick](https://blog.feedly.com/tricks-of-the-trade-logsumexp/) to normalize the log weights, avoiding divide by 0 when weights are very negative. It also fixes the scorer for `log-categorical`, which seemed to be calculating a CDF, rather than a PDF, before.