### PR TITLE
Bump version of lein-tools-deps to account for patch to the PATH bug.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :resource-paths ["tutorial/resources"]
   :dependencies [[org.clojure/data.json "0.2.6"]
                  [lein-jupyter "0.1.16"]]
-  :plugins [[lein-tools-deps "0.4.1"]
+  :plugins [[lein-tools-deps "0.4.3"]
             [lein-jupyter "0.1.16"]]
   :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
   :lein-tools-deps/config {:config-files [:install :user :project]})


### PR DESCRIPTION
Fixes #111.

The upstream issue (fixed in 0.4.3) that this diff resolves is RickMoynihan/lein-tools-deps#62.