### PR TITLE
Clarify installation instructions, work without Maven installed

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,13 @@
 # Installing metaprob-in-clojure
 
-The system is not yet packaged up for easy installation.
+Setting up a development environment for Metaprob is still a somewhat
+manual process. Note that what follows are instructions for those
+interesting in working on Metaprob itself or users wanting to use
+Metaprob for specific projects.
+
+If you're interested in learning and experimenting with Metaprob, we
+strongly recommend starting with the [Tutorial](tutorial/README.md)
+rather than following these instructions.
 
 ## Install Java
 

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ tags:
 
 # Targets for manipulating Docker below.
 docker-build:
+	mkdir -p $(HOME)/.m2
 	docker build -t probcomp/metaprob-clojure:latest .
 .PHONY: docker-build
 

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ tags:
 
 # Targets for manipulating Docker below.
 docker-build:
-	mkdir -p $(HOME)/.m2
+	mkdir -p $(HOME)/.m2/repository
 	docker build -t probcomp/metaprob-clojure:latest .
 .PHONY: docker-build
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Generic inference algorithms like rejection sampling, sampling/importance resamp
 
 ## Getting started
 
-For those eager to learn and experiment with Metaprob, we recommend starting with the tutorial notebook, a Docker container which runs a Jupyter notebook containing the language and learning material. Instructions can be found [here](tutorial/README.md).
+For those eager to learn and experiment with Metaprob we recommend starting with the tutorial notebook: a Docker container which runs a Jupyter notebook containing the language and learning material. Instructions for its installation and use can be found [here](tutorial/README.md).
 
 To work on Metaprob itself, please refer to the [installation instructions](INSTALL.md).
 

--- a/README.md
+++ b/README.md
@@ -90,9 +90,16 @@ Generic inference algorithms like rejection sampling, sampling/importance resamp
 (nth (map first particles) (log-categorical (map second particles)))))
 ```
 
+## Getting started
+
+For those eager to learn and experiment with Metaprob, we recommend starting with the tutorial notebook, a Docker container which runs a Jupyter notebook containing the language and learning material. Instructions can be found [here](tutorial/README.md).
+
+To work on Metaprob itself, please refer to the [installation instructions](INSTALL.md).
+
 ## Documentation
 
-  * [Installation instructions](INSTALL.md)
+  * [Tutorial instructions](tutorial/README.md)
+  * [Contributor installation instructions](INSTALL.md)
   * [Using metaprob-in-clojure](doc/interaction.md)
   * [Language reference](doc/language.md)
   * [Probabilistic inference examples](doc/examples.md)

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -2,7 +2,15 @@
 
 This directory contains a work-in-progress tutorial for Metaprob, in the file `Tutorial.ipynb`. The tutorial should generally be run in a Docker container, though it's also possible to run as a Clojure / Jupyter project directly on your machine.
 
-If you're interested in using Metaprob outside a Jupyter notebook or contributing to the language itself, please refer to the [installation instructions](INSTALL.md).
+If you're interested in using Metaprob outside a Jupyter notebook or contributing to the language itself, please refer to the general [installation instructions](INSTALL.md).
+
+## Getting started
+
+First, you should clone this repository:
+
+    git clone https://github.com/probcomp/metaprob.git
+
+Once the repository is cloned, `cd` into the newly-created `metaprob` directory.
 
 ## Running in a container
 
@@ -14,11 +22,12 @@ To run the Metaprob tutorial in a Docker you will need to run the following comm
    of this repository. Note that you should only need to run this
    command once- this step can be skipped in the future when starting
    the container.
-3. Run the Docker image with `make docker-notebook`. A URL like `http://(<container-id> or 127.0.0.1):8888/?token=<token>` will be printed.
-4. Copy the URL from your terminal into the address bar of your browser.
-5. Replace `(<container-id> or 127.0.0.1)` with `127.0.0.1`. This should leave you with a URL like `http://127.0.0.1:8888/?token=<token>`.
-6. Hit enter to navigate to the provided URL.
-7. Click on `Tutorial.ipynb`.
+3. Confirm the container you built is present on your system. Running `docker images | grep probcomp` should print a line starting with `probcomp/metaprob-clojure`.
+4. Run the Docker image with `make docker-notebook`. A URL like `http://(<container-id> or 127.0.0.1):8888/?token=<token>` will be printed.
+5. Copy the URL from your terminal into the address bar of your browser.
+6. Replace `(<container-id> or 127.0.0.1)` with `127.0.0.1`. This should leave you with a URL like `http://127.0.0.1:8888/?token=<token>`.
+7. Hit enter to navigate to the provided URL.
+8. Click on `Tutorial.ipynb`.
 
 ### Installing Docker
 

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -2,6 +2,8 @@
 
 This directory contains a work-in-progress tutorial for Metaprob, in the file `Tutorial.ipynb`. The tutorial should generally be run in a Docker container, though it's also possible to run as a Clojure / Jupyter project directly on your machine.
 
+If you're interested in using Metaprob outside a Jupyter notebook or contributing to the language itself, please refer to the [installation instructions](INSTALL.md).
+
 ## Running in a container
 
 To run the Metaprob tutorial in a Docker you will need to run the following commands from the root of this repository (in the same directory as `Makefile`):


### PR DESCRIPTION
This fixes a few things which came up in feedback from @cameronfreer .

First, `make docker-image` was not working on host machines without a Maven environment (since we mount `~/.m2` in the running container, in order leverage the host machine's Maven cache). This PR works around that problem by making the `~/.m2/repository` directory if it doesn't already exist. A good case could be made that a better solution would be to use a local-to-this-project maven cache, such that installing Metaprob does not affect the host system outside the Metaprob directory, but for now this should work.

Second, this PR clarifies installation instructions for different users: those wanting to run the tutorial vs those who want to work on Metaprob itself (or use it for non-notebook projects).