### PR TITLE
20190211 alexlew fix log categorical

### DIFF
--- a/src/metaprob/distributions.clj
+++ b/src/metaprob/distributions.clj
@@ -168,7 +168,9 @@
           (map (gen [x] (- x max-score)) scores))
        (define weights (map exp numerically-stable-scores))
        (define log-normalizer (+ (log (apply + weights)) max-score))
-       (map (gen [w] (exp (- w log-normalizer))) scores)))
+       (if (> (apply + weights) 0)
+         (map (gen [w] (exp (- w log-normalizer))) scores)
+         (map (gen [w] (/ 1 (count scores))) scores))))
 
 ;; ----------------------------------------------------------------------------
 ;; I'm going to defer the implementation of beta until later;

--- a/src/metaprob/distributions.clj
+++ b/src/metaprob/distributions.clj
@@ -154,7 +154,7 @@
                       (scan (+ i 1) (rest probs) p))))
      (scan 0 (scores-to-probabilities scores) 0.0))
    (gen [i [scores]]
-     (nth (scores-to-probabilities scores) i))))
+     (log (nth (scores-to-probabilities scores) i)))))
 
 
 
@@ -162,28 +162,13 @@
 ;;  ^:private
 (define scores-to-probabilities
   (gen [scores]
-
-       ;; Alex's
-       (define weights (map exp scores))
-       (define normalizer (apply + weights))
-       (map (gen [w] (/ w normalizer)) weights)
-
-       (define weights (map exp scores))
-       (define normalizer (apply + weights))
-       (if (> normalizer 0)
-         (map (gen [w] (/ w normalizer)) weights)
-         (map (gen [w] (/ 1 (count weights))) weights))
-
        ;; master branch's
-       ;; (define max-score (apply clojure.core/max scores))
-       ;; (define numerically-stable-scores
-       ;;   (map (gen [x] (- x max-score))
-       ;;        (to-immutable-list scores)))
-       ;; (define weights (map exp numerically-stable-scores))
-       ;; (define log-normalizer (+ (log (apply + weights)) max-score))
-       ;; (map (gen [w] (exp (- w log-normalizer))) (to-immutable-list scores))
-    ))
-
+       (define max-score (apply clojure.core/max scores))
+       (define numerically-stable-scores
+          (map (gen [x] (- x max-score)) scores))
+       (define weights (map exp numerically-stable-scores))
+       (define log-normalizer (+ (log (apply + weights)) max-score))
+       (map (gen [w] (exp (- w log-normalizer))) scores)))
 
 ;; ----------------------------------------------------------------------------
 ;; I'm going to defer the implementation of beta until later;


### PR DESCRIPTION
This fixes two things about the current implementation of `log-categorical`:

1. The scorer for the distribution had been turning a probability, instead of a log probability.
2. The `scores-to-probabilities` function had reverted to the version on my `explorations` branch, instead of the fixed version from `master`. This goes back to the version from master, plus one extra fix for stability: when all scores passed to `log-categorical` are negative infinity, we won't error.