### PR TITLE
Fix websocket / Jupyter regression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,18 @@ COPY --chown=metaprob:metaprob ./deps.edn $METAPROB_DIR
 COPY --chown=metaprob:metaprob ./project.clj $METAPROB_DIR
 RUN clojure -e "(clojure-version)"
 
-# Install the Clojure jupyter kernel.
+# downgrade tornado.
+# see https://stackoverflow.com/questions/54963043/jupyter-notebook-no-connection-to-server-because-websocket-connection-fails
+
+USER root
+RUN pip3 uninstall -y tornado
+RUN pip3 install tornado==5.1.1
+
+USER metaprob
 
 RUN lein jupyter install-kernel
+
+
 
 # Copy in the rest of our source.
 

--- a/Makefile
+++ b/Makefile
@@ -127,5 +127,10 @@ docker-notebook:
 		--mount type=bind,source=${CURDIR},destination=/home/metaprob/projects/metaprob-clojure \
 		--publish 8888:8888/tcp \
 		probcomp/metaprob-clojure:latest \
-		bash -c "lein jupyter notebook --ip=0.0.0.0 --port=8888 --no-browser --notebook-dir ./tutorial"
+		bash -c "lein jupyter notebook \
+			--ip=0.0.0.0 \
+			--port=8888 \
+			--no-browser \
+			--NotebookApp.token= \
+			--notebook-dir ./tutorial"
 .PHONY: docker-notebook

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -23,14 +23,7 @@ To run the Metaprob tutorial in a Docker you will need to run the following comm
    command once- this step can be skipped in the future when starting
    the container.
 3. Confirm the container you built is present on your system. Running `docker images | grep probcomp` should print a line starting with `probcomp/metaprob-clojure`.
-4. Run the Docker image with `make docker-notebook`. A message along the lines of
-
-
-    [I 04:07:35.953 NotebookApp] The Jupyter Notebook is running at:
-    [I 04:07:35.953 NotebookApp] http://(fc7b1750d0a9 or 127.0.0.1):8888/
-
-will be displayed.
-
+4. Run the Docker image with `make docker-notebook`. Eventually a message including `The Jupyter Notebook is running at:` should be displayed.
 5. In your browser, visit [http://127.0.0.1:8888/](http://127.0.0.1:8888)
 6. Click on `Tutorial.ipynb`.
 

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -23,11 +23,16 @@ To run the Metaprob tutorial in a Docker you will need to run the following comm
    command once- this step can be skipped in the future when starting
    the container.
 3. Confirm the container you built is present on your system. Running `docker images | grep probcomp` should print a line starting with `probcomp/metaprob-clojure`.
-4. Run the Docker image with `make docker-notebook`. A URL like `http://(<container-id> or 127.0.0.1):8888/?token=<token>` will be printed.
-5. Copy the URL from your terminal into the address bar of your browser.
-6. Replace `(<container-id> or 127.0.0.1)` with `127.0.0.1`. This should leave you with a URL like `http://127.0.0.1:8888/?token=<token>`.
-7. Hit enter to navigate to the provided URL.
-8. Click on `Tutorial.ipynb`.
+4. Run the Docker image with `make docker-notebook`. A message along the lines of
+
+
+    [I 04:07:35.953 NotebookApp] The Jupyter Notebook is running at:
+    [I 04:07:35.953 NotebookApp] http://(fc7b1750d0a9 or 127.0.0.1):8888/
+
+will be displayed.
+
+5. In your browser, visit [http://127.0.0.1:8888/](http://127.0.0.1:8888)
+6. Click on `Tutorial.ipynb`.
 
 ### Installing Docker
 


### PR DESCRIPTION
This downgrades the Tornado version installed, I believe, as part of Jupyter's installation, which breaks the ability of Jupyter to establish websocket connections.

This is a regression[1] on the part of Jupyter, which I should be fixed upstream at some point. Until then, this works around the problem.

To test:

`make docker-build` to build a new metaprob image. Then `make docker-notebook` to run the notebook in that image. 

You *may* need to remove your existing metaprob image, then build a new image, then run the notebook in container made from the image.

To remove the existing image, you'll need to remove any containers based on the image. First try `docker rmi probcomp/metaprob-clojure`. If that fails, try `docker ps -a` to find any containers based on that image. Use `docker rm <image id>` to remove all such images, then try the `docker rmi` command again.

Once you've removed the existing `probcomp/metaprob-clojure` image, use `make docker-build` to build a new image. Then `make docker-notebook` to try the notebook again.

[1] More information on regression
https://stackoverflow.com/questions/54963043/jupyter-notebook-no-connection-to-server-because-websocket-connection-fails
https://github.com/jupyter/notebook/issues/4399