### PR TITLE
Run ClojureScript tests in both JVM-hosted and self-hosted contexts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,13 @@ FROM clojure:lein-2.8.1
 # Install curl so we can use it to download the Clojure command line tools,
 # install time so we can measure how long it takes to run the examples, install
 # rlwrap for use with clj, and install pip so we can install jupyter.
-
+RUN add-apt-repository ppa:mfikes/planck
 RUN apt-get update -qq \
       && apt-get upgrade -qq \
       && apt-get install -qq -y \
         curl \
         nodejs \
+        planck \
         time \
         rlwrap \
         python3-pip
@@ -64,8 +65,6 @@ RUN pip3 install tornado==5.1.1
 USER metaprob
 
 RUN lein jupyter install-kernel
-
-
 
 # Copy in the rest of our source.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,20 @@ FROM clojure:lein-2.8.1
 
 # Install curl so we can use it to download the Clojure command line tools,
 # install time so we can measure how long it takes to run the examples, install
-# rlwrap for use with clj, and install pip so we can install jupyter.
-RUN add-apt-repository ppa:mfikes/planck
+# rlwrap for use with clj, and install pip so we can install jupyter, and
+# install cmake and xxd so we can build Planck.
 RUN apt-get update -qq \
       && apt-get upgrade -qq \
       && apt-get install -qq -y \
+        cmake \
         curl \
         nodejs \
-        planck \
         time \
         rlwrap \
-        python3-pip
+        python3-pip \
+        xxd
+
+# Install Node so we can run our tests in JVM-hosted Clojurescript mode.
 
 RUN ln -s /usr/bin/nodejs /usr/bin/node
 
@@ -27,6 +30,22 @@ ENV CLOJURE_VERSION 1.9.0.394
 RUN curl -O https://download.clojure.org/install/linux-install-${CLOJURE_VERSION}.sh \
       && chmod +x linux-install-${CLOJURE_VERSION}.sh \
       && ./linux-install-${CLOJURE_VERSION}.sh
+
+# Install Planck so we can run our tests in self-hosted mode.
+
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+RUN apt-get install -qq -y \
+      libjavascriptcoregtk-4.0 \
+      libglib2.0-dev \
+      libzip-dev \
+      libcurl4-gnutls-dev \
+      libicu-dev
+
+RUN git clone https://github.com/planck-repl/planck.git
+RUN cd planck && script/build --fast \
+      && script/install \
+      && planck -h \
+      && cd ..
 
 # Install jupyter.
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ cljstest:
 cljsclean:
 	rm -Rf out
 
+cljsselftest:
+	plk -c`clojure -Acljs:test -Spath` -m metaprob.test-runner
+.PHONY: cljsselftest
+
 # This target is referenced in README.md
 bin/lein:
 	wget "https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein"
@@ -29,7 +33,7 @@ bin/lein:
 	bin/lein classpath > $@
 
 # Incudes long-running tests
-test: cljtest cljtestlong cljstest
+test: cljtest cljtestlong cljstest cljsselftest
 .PHONY: test
 
 cljtest:


### PR DESCRIPTION
## What and why?
See #134. Fixes #134.

## How?
This is done by leveraging [Planck](http://planck-repl.org/), a stand-alone ClojureScript REPL for macOS and Linux. Planck shells out to the Clojure command-line tools to generate a classpath for our project, and then we have Planck run the test suite as normal. 

In order to make this work for developers and for our continuous integration process this pull request modifies our `Dockerfile` to build and install Planck.

## Future work
We already install [Node](https://nodejs.org/en/) to run our ClojureScript tests in the non-self-hosted context, so we ought to be able to leverage `node` and `cljs.js` to run our tests in the self-hosted context without needing Planck.