### PR TITLE
Simplify Dockerfile, clean up after tests in Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,19 +33,21 @@ RUN curl -O https://download.clojure.org/install/linux-install-${CLOJURE_VERSION
 
 # Install Planck so we can run our tests in self-hosted mode.
 
-RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
-RUN apt-get install -qq -y \
-      libjavascriptcoregtk-4.0 \
-      libglib2.0-dev \
-      libzip-dev \
-      libcurl4-gnutls-dev \
-      libicu-dev
+RUN apt-get update \
+        && apt-get install -y --no-install-recommends apt-utils \
+        && apt-get install -qq -y \
+          libjavascriptcoregtk-4.0 \
+          libglib2.0-dev \
+          libzip-dev \
+          libcurl4-gnutls-dev \
+          libicu-dev
 
-RUN git clone https://github.com/planck-repl/planck.git
-RUN cd planck && script/build --fast \
-      && script/install \
-      && planck -h \
-      && cd ..
+RUN git clone https://github.com/planck-repl/planck.git \
+        && cd planck \
+        && script/build --fast \
+        && script/install \
+        && planck -h \
+        && cd ..
 
 # Install jupyter.
 

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ docker-build:
 .PHONY: docker-build
 
 docker-test:
-	docker run -t probcomp/metaprob-clojure:latest bash -c "make test"
+	docker run --rm -t probcomp/metaprob-clojure:latest bash -c "make test"
 .PHONY: docker-test
 
 docker-bash:


### PR DESCRIPTION
Fixes #139.

Combined RUN commands in Dockerfile, to reduce the number of overlay filesystems created.

Also removes the Docker VM created by `make docker-test`, since it doesn't do anyone any good by sticking around. 