### PR TITLE
Pin Planck to a specific version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,8 @@ RUN apt-get update \
 
 RUN git clone https://github.com/planck-repl/planck.git \
         && cd planck \
+        && git fetch --all --tags \
+        && git checkout tags/2.21.0 \
         && script/build --fast \
         && script/install \
         && planck -h \


### PR DESCRIPTION
An upstream change in Planck, which we use to run our tests in the self-hosted context, caused our Docker build to start failing. This pull request pins the version of Planck we build for testing to version `2.22.0` which is known to work.