### PR TITLE
Added missing symbol infer-and-score to namespace requires in 3 files…

### DIFF
--- a/src/metaprob/examples/aide.clj
+++ b/src/metaprob/examples/aide.clj
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [map replicate apply])
   (:require [metaprob.trace :refer :all]
             [metaprob.generative-functions :refer :all]
-            [metaprob.prelude :refer [map replicate expt]]
+            [metaprob.prelude :refer [map replicate expt infer-and-score]]
             [metaprob.distributions :refer :all]
             [clojure.pprint :refer [pprint]]
             [metaprob.inference :refer :all]))

--- a/src/metaprob/examples/curve_fitting.clj
+++ b/src/metaprob/examples/curve_fitting.clj
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [map replicate apply])
   (:require [metaprob.trace :refer :all]
             [metaprob.generative-functions :refer :all]
-            [metaprob.prelude :refer [map expt replicate]]
+            [metaprob.prelude :refer [map expt replicate infer-and-score]]
             [metaprob.distributions :refer :all]
             [clojure.pprint :refer [pprint]]
             [metaprob.inference :refer :all]))

--- a/src/metaprob/examples/multimixture_dsl.clj
+++ b/src/metaprob/examples/multimixture_dsl.clj
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [map replicate apply])
   (:require [metaprob.trace :refer :all]
             [metaprob.generative-functions :refer :all]
-            [metaprob.prelude :refer [map log apply]]
+            [metaprob.prelude :refer [map log apply infer-and-score]]
             [metaprob.distributions :refer :all]
             [clojure.pprint :refer [pprint]]
             [metaprob.inference :refer :all]))


### PR DESCRIPTION
… in examples

This PR just adds missing infer-and-score symbol to requires in 3 example files. I spotted the issue while trying to load one of them, as one of the first things after cloning the repo. 

I hope that helps and will save the next guy some grief. 