### PR TITLE
Document the fact that one must use `lein repl` to get the right classpath, and add a target that imports all the tests

### DIFF
--- a/doc/interaction.md
+++ b/doc/interaction.md
@@ -26,11 +26,16 @@ curve is steep if you haven't used emacs before.
 
 To get an interactive read-eval-print loop at the shell:
 
-    $ clj
+    $ lein repl
 
 This should be done with the working directory set to the directory that
 contains `deps.edn`, which in this setup would normally be the clone of the
 `metaprob` repository.
+
+One difference between running `lein repl` versus running `clj` is that `lein
+repl` will set the classpath according to the project's configuration.  Thus,
+if you simply use `clj`, you may get import errors when trying to import or run
+code.
 
 ### Using Clojure under Emacs
 

--- a/doc/interaction.md
+++ b/doc/interaction.md
@@ -213,7 +213,7 @@ tests instead of the REPL.  The disadvantages of tests compared to the REPL are
 You can run tests either from the shell or from inside Clojure.  From
 the Clojure REPL: Run tests for all modules in the project:
 
-    (require 'metaprob.examples.all)
+    (require 'metaprob.all-tests)
     (require '[clojure.test :refer :all])
     (run-all-tests)
 

--- a/test/metaprob/all_tests.cljc
+++ b/test/metaprob/all_tests.cljc
@@ -1,0 +1,7 @@
+(ns metaprob.all-tests
+  (:require [metaprob.compositional-test]
+            [metaprob.distributions-test]
+            [metaprob.inference-test]
+            [metaprob.prelude-test]
+            [metaprob.syntax-test]
+            [metaprob.trace-test]))

--- a/test/metaprob/test_runner.cljs
+++ b/test/metaprob/test_runner.cljs
@@ -1,15 +1,10 @@
 (ns metaprob.test-runner
   (:require [cljs.test :as test :include-macros true]
+            [metaprob.all-tests]
             [metaprob.autotrace]
             [metaprob.code-handlers]
-            [metaprob.compositional-test]
-            [metaprob.distributions-test]
             [metaprob.expander]
-            [metaprob.generative-functions]
-            [metaprob.inference-test]
-            [metaprob.prelude-test]
-            [metaprob.syntax-test]
-            [metaprob.trace-test]))
+            [metaprob.generative-functions]))
 
 (defn -main
   [& args]


### PR DESCRIPTION
See https://github.com/probcomp/metaprob/issues/150#issuecomment-496029834.